### PR TITLE
Initialize resource timestamp on first update

### DIFF
--- a/utils/game_logic.py
+++ b/utils/game_logic.py
@@ -15,7 +15,12 @@ def update_resources(nation):
     if resources.last_updated:
         time_diff = now - resources.last_updated
         elapsed_hours = time_diff.total_seconds() / 3600  # Convert to hours
-    
+    else:
+        # Initialize the timestamp on the first update so future calls work correctly
+        resources.last_updated = now
+        db.session.commit()
+        return
+
     if elapsed_hours > 0:
         # Calculate production rates based on population distribution and technology
         raw_materials_rate = get_production_rate(nation, 'raw_materials')


### PR DESCRIPTION
## Summary
- Avoid perpetual zero resource updates by setting `last_updated` when a nation's resources are first processed
- Early commit ensures future calls compute elapsed time correctly

## Testing
- `python -m py_compile utils/game_logic.py`


------
https://chatgpt.com/codex/tasks/task_e_689adc1fe5e083259b492d8108e4bfc9